### PR TITLE
Fixes to make builds more portable and customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ portal_pak_modified/
 
 resource/closecaption_*
 
-tools/skeletool64
-tools/vtf2png
+tools/skeletool64*
+tools/vtf2png*
 
 skelatool64/*.zip*
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 CODESEGMENT =	build/codesegment
 
 BOOT		=	$(N64_ROOT)/usr/lib/n64/PR/bootcode/boot.6102
-BOOT_OBJ	=	build/boot.6102.o
+BOOT_OBJ	=	build/boot.o
 
 UCODE_RSP	=	$(N64_ROOT)/usr/lib/n64/PR/rspboot.o
 RSP_OBJ		=	build/rspboot.o

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #        $Revision: 1.1.1.1 $
 #        $Date: 2002/05/02 03:27:21 $
 # --------------------------------------------------------------------
-include /usr/include/n64/make/PRdefs
+include $(N64_ROOT)/usr/include/n64/make/PRdefs
 
 SKELATOOL64:=skelatool64/skeletool64
 VTF2PNG:=vtf2png
@@ -20,7 +20,7 @@ $(SKELATOOL64):
 	@$(MAKE) -C skelatool64
 
 OPTIMIZER		:= -Os
-LCDEFS			:= -DDEBUG -g -Isrc/ -I/usr/include/n64/nustd -Werror -Wall
+LCDEFS			:= -DDEBUG -g -Isrc/ -I$(N64_ROOT)/usr/include/n64/nustd -Werror -Wall
 N64LIB			:= -lultra_rom -lnustd
 
 ifeq ($(PORTAL64_WITH_DEBUGGER),1)
@@ -51,16 +51,27 @@ endif
 
 CODESEGMENT =	build/codesegment
 
-BOOT		=	/usr/lib/n64/PR/bootcode/boot.6102
+BOOT		=	$(N64_ROOT)/usr/lib/n64/PR/bootcode/boot.6102
 BOOT_OBJ	=	build/boot.6102.o
 
-OBJECTS		=	$(ASMOBJECTS) $(BOOT_OBJ)
+UCODE_RSP	=	$(N64_ROOT)/usr/lib/n64/PR/rspboot.o
+RSP_OBJ		=	build/rspboot.o
+
+UCODE_GSP	=	$(N64_ROOT)/usr/lib/n64/PR/gspF3DEX2.fifo.o
+GSP_OBJ		=	build/gspMain.o
+
+UCODE_ASP	=	$(N64_ROOT)/usr/lib/n64/PR/aspMain.o
+ASP_OBJ		=	build/aspMain.o
+
+UCODE_OBJS	=	$(RSP_OBJ) $(GSP_OBJ) $(ASP_OBJ)
+
+OBJECTS		=	$(ASMOBJECTS) $(BOOT_OBJ) $(UCODE_OBJS)
 
 DEPS = $(patsubst %.c, build/%.d, $(CODEFILES)) $(patsubst %.c, build/%.d, $(DATAFILES))
 
 -include $(DEPS)
 
-LCINCS =	-I/usr/include/n64/PR 
+LCINCS =	-I$(N64_ROOT)/usr/include/n64/PR
 LCDEFS +=	-DF3DEX_GBI_2 -DSCENE_SCALE=${SCENE_SCALE}
 #LCDEFS +=	-DF3DEX_GBI_2 -DFOG
 #LCDEFS +=	-DF3DEX_GBI_2 -DFOG -DXBUS
@@ -68,7 +79,7 @@ LCDEFS +=	-DF3DEX_GBI_2 -DSCENE_SCALE=${SCENE_SCALE}
 
 LDIRT  =	$(BASE_TARGET_NAME).elf $(CP_LD_SCRIPT) $(BASE_TARGET_NAME).z64 $(BASE_TARGET_NAME)_no_debug.map $(ASMOBJECTS)
 
-LDFLAGS =	-L/usr/lib/n64 $(N64LIB)  -L$(N64_LIBGCCDIR) -lgcc
+LDFLAGS =	-L$(N64_ROOT)/usr/lib/n64 $(N64LIB)  -L$(N64_LIBGCCDIR) -lgcc
 
 default:	english_audio
 
@@ -532,6 +543,12 @@ build/src/audio/subtitles.h build/src/audio/subtitles.c build/subtitles.ld: vpk/
 
 $(BOOT_OBJ): $(BOOT)
 	$(OBJCOPY) -I binary -B mips -O elf32-bigmips $< $@
+
+$(RSP_OBJ): $(UCODE_RSP)
+$(GSP_OBJ): $(UCODE_GSP)
+$(ASP_OBJ): $(UCODE_ASP)
+$(UCODE_OBJS):
+	cp $< $@
 
 # without debugger
 

--- a/portal.ld
+++ b/portal.ld
@@ -26,7 +26,7 @@ SECTIONS
    BEGIN_SEG(boot, 0x04000000)
    {
       build/asm/rom_header.o(.text);
-      build/boot.6102.o(.data);
+      build/boot.o(.data);
    }
    END_SEG(boot)
 

--- a/portal.ld
+++ b/portal.ld
@@ -34,15 +34,15 @@ SECTIONS
    {
       build/asm/entry.o(.text);
       CODE_SEGMENT(.text);
-      /usr/lib/n64/PR/rspboot.o(.text);
-      /usr/lib/n64/PR/gspF3DEX2.fifo.o(.text);
-      /usr/lib/n64/PR/aspMain.o(.text);
+      build/rspboot.o(.text);
+      build/gspMain.o(.text);
+      build/aspMain.o(.text);
 
       /* data */
       CODE_SEGMENT(.data*);
-      /usr/lib/n64/PR/rspboot.o(.data*);
-      /usr/lib/n64/PR/gspF3DEX2.fifo.o(.data*);
-      /usr/lib/n64/PR/aspMain.o(.data*);
+      build/rspboot.o(.data*);
+      build/gspMain.o(.data*);
+      build/aspMain.o(.data*);
 
       /* rodata */
       CODE_SEGMENT(.rodata*);

--- a/skelatool64/.gitignore
+++ b/skelatool64/.gitignore
@@ -5,7 +5,7 @@ assimp/
 cimg/
 yaml-cpp/
 output/
-skeletool64
+skeletool64*
 dna.txt
 build/
 images/

--- a/skelatool64/main.cpp
+++ b/skelatool64/main.cpp
@@ -3,12 +3,15 @@
 
 #include <iostream>
 #include <fstream>
-#include <execinfo.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <assimp/postprocess.h>
+
+#ifndef WIN32
+#include <execinfo.h>
+#endif
 
 #include "src/SceneWriter.h"
 #include "src/CommandLineParser.h"
@@ -25,15 +28,16 @@
 #include "src/lua_generator/LuaGenerator.h"
 
 void handler(int sig) {
-  void *array[10];
-  size_t size;
-
-  // get void*'s for all entries on the stack
-  size = backtrace(array, 10);
-
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
-  backtrace_symbols_fd(array, size, STDERR_FILENO);
+
+#ifndef WIN32
+    // TODO: proper backtraces on Windows
+    void *array[10];
+    size_t size = backtrace(array, 10);
+    backtrace_symbols_fd(array, size, STDERR_FILENO);
+#endif
+
   exit(1);
 }
 

--- a/skelatool64/makefile
+++ b/skelatool64/makefile
@@ -1,5 +1,5 @@
 
-GCC_FLAGS = -Wall -Werror -g -rdynamic -I./yaml-cpp/include 
+GCC_FLAGS = -Wall -Werror -g -rdynamic -I./yaml-cpp/include -DYAML_CPP_STATIC_DEFINE
 
 LINKER_FLAGS = -L./yaml-cpp -lassimp -lyaml-cpp -lpng -ltiff -llua5.4 -ldl
 

--- a/tools/level_scripts/subtitle_generate.py
+++ b/tools/level_scripts/subtitle_generate.py
@@ -108,7 +108,7 @@ def dump_lines(sourcefile_path, lines):
     if not os.path.exists(os.path.dirname(os.path.abspath(sourcefile_path))):
         os.makedirs(os.path.dirname(os.path.abspath(sourcefile_path)))
 
-    with open(sourcefile_path, "w") as f:
+    with open(sourcefile_path, "w", encoding="utf-8") as f:
         f.writelines(lines)
 
 def get_caption_keys_values_language(lines):


### PR DESCRIPTION
I set up a build environment on Windows recently an encountered some problems along the way that are fixed here.

* Explicitly specify UTF-8 in subtitle generation Python script
* Ignore vtf2png and skeletool if they have a file extension (i.e., .exe)
* Add `N64_ROOT` environment variable to optionally specify toolchain location. This should help anybody who wants to install on their host system but not system-wide (Windows or not).
* Do not use backtrace in Skeletool on Windows

I also made it easier to change the microcode/bootcode that is used. Useful for changing CIC type or switching to an open one (although the Makefile will likely need to be overhauled at some point for libdragon).

Tested on both Windows (MSYS2 + MinGW-w64) and Linux (Arch with Docker).