### PR TITLE
Tweak for 3D sound attenuation.

### DIFF
--- a/src/audio/soundplayer.c
+++ b/src/audio/soundplayer.c
@@ -106,8 +106,10 @@ void soundPlayerDetermine3DSound(struct Vector3* at, struct Vector3* velocity, f
         return;
     }
 
+    float distanceSqrt = sqrtf(distance);
+    
     // attenuate the volume
-    *volumeOut = *volumeIn / distance;
+    *volumeOut = *volumeIn / distanceSqrt;
 
     // clamp to full volume
     if (*volumeOut > 1.0f) {
@@ -128,7 +130,7 @@ void soundPlayerDetermine3DSound(struct Vector3* at, struct Vector3* velocity, f
     struct Vector3 relativeVelocity;
     vector3Sub(velocity, &nearestListener->velocity, &relativeVelocity);
 
-    float invDist = 1.0f / sqrtf(distance);
+    float invDist = 1.0f / distanceSqrt;
 
     float directionalVelocity = -vector3Dot(&offset, &relativeVelocity) * invDist;
 


### PR DESCRIPTION
This slightly changes the calculation for sound attenuation over distance for the 3D audio.   It makes the "curve" much less abrupt such that you can actually hear orbs, platforms, doors, etc without having to be right on top of them.   It sounds much closer to the OG game and really brings the later chambers to life.

Thank you for trying to save this amazing project!