### PR TITLE
Fix Test Chamber 13 Escape Hatch cutscene triggers (issue #10)

### DIFF
--- a/assets/test_chambers/test_chamber_08/test_chamber_08.yaml
+++ b/assets/test_chambers/test_chamber_08/test_chamber_08.yaml
@@ -23,10 +23,8 @@ cutscenes:
     - set_signal room_exit
 operators:
   - room_exit = room_exit_0 and room_exit_1
-  - side_cube_access = player_in_side and has_cube_side
-  - main_cube_access = player_in_main and has_cube_main
-  - has_cube_any = has_cube_side or has_cube_main
-  - side_cube_access_with_door = room_enter and has_cube_any
-  - direct_cube_access = side_cube_access or main_cube_access
-  - any_cube_access = direct_cube_access or side_cube_access_with_door
+  - side_cube_access_direct = player_in_side and has_cube_side
+  - side_cube_access_door = room_enter and has_cube_side
+  - side_cube_access = side_cube_access_direct or side_cube_access_door
+  - any_cube_access = side_cube_access or has_cube_main
   - trapped = not any_cube_access

--- a/assets/test_chambers/test_chamber_08/test_chamber_08.yaml
+++ b/assets/test_chambers/test_chamber_08/test_chamber_08.yaml
@@ -20,11 +20,11 @@ cutscenes:
     - q_sound 08_PART1_TRAPPED_1 CH_GLADOS PORTAL_08_PART1_TRAPPED_1
     - q_sound 08_PART1_TRAPPED_2 CH_GLADOS PORTAL_08_PART1_TRAPPED_2
     - wait_for_channel CH_GLADOS
-    - set_signal room_exit
+    - set_signal escape_hatch
 operators:
   - room_exit = room_exit_0 and room_exit_1
-  - side_cube_access_direct = player_in_side and has_cube_side
-  - side_cube_access_door = room_enter and has_cube_side
-  - side_cube_access = side_cube_access_direct or side_cube_access_door
+  - room_exit = room_exit or escape_hatch
+  - side_room_access = player_in_side or room_enter
+  - side_cube_access = side_room_access and has_cube_side
   - any_cube_access = side_cube_access or has_cube_main
   - trapped = not any_cube_access


### PR DESCRIPTION
See Issue #10 

* If the player is inside the side_room without a cube, they can still stand on the button and shoot a portal through the door. `trapped` is therefore never reached if the player is inside the side_room.
* The old `main_cube_access` is redundant, as the main room can always be accessed as long as the player is not inside the exit corridor with the exit door closed. This also fixes the cutscene from triggering if the player exits the chamber normally as described.
* Trapping the first cube in the side_room without the side_room door being open doesn't trigger the cutscene anymore, just like in the original game. The player can still stand on one of the buttons.
* Trapping both cubes in the side_room without the door being open and the player being in the main_room does trigger the cutscene as it should.
* Trapping both cubes in the exit corridor triggers the cutscene as it should.