### PR TITLE
Functionality to deactivate buttons via signals

### DIFF
--- a/src/levels/level_definition.h
+++ b/src/levels/level_definition.h
@@ -216,6 +216,7 @@ struct ButtonDefinition {
     short roomIndex;
     short signalIndex;
     short cubeSignalIndex;
+    short deactivateSignalIndex;
 };
 
 struct SwitchDefinition {

--- a/src/scene/button.c
+++ b/src/scene/button.c
@@ -46,6 +46,8 @@ struct ColliderTypeData gButtonCollider = {
 
 #define PRESSED_WITH_CUBE               2
 
+#define CUBE_PRESS_IDLE_FRAMES          2
+
 void buttonRender(void* data, struct DynamicRenderDataList* renderList, struct RenderState* renderState) {
     struct Button* button = (struct Button*)data;
 
@@ -76,89 +78,96 @@ void buttonRender(void* data, struct DynamicRenderDataList* renderList, struct R
 
 void buttonInit(struct Button* button, struct ButtonDefinition* definition) {
     dynamicAssetAnimatedModel(PROPS_BUTTON_DYNAMIC_ANIMATED_MODEL);
-
+    
     collisionObjectInit(&button->collisionObject, &gButtonCollider, &button->rigidBody, 1.0f, COLLISION_LAYERS_TANGIBLE);
     rigidBodyMarkKinematic(&button->rigidBody);
     collisionSceneAddDynamicObject(&button->collisionObject);
-
+    
     button->rigidBody.transform.position = definition->location;
     quatIdent(&button->rigidBody.transform.rotation);
     button->rigidBody.transform.scale = gOneVec;
     button->rigidBody.currentRoom = definition->roomIndex;
-
+    
     collisionObjectUpdateBB(&button->collisionObject);
-
+    
     button->dynamicId = dynamicSceneAdd(button, buttonRender, &button->rigidBody.transform.position, 0.84f);
     button->signalIndex = definition->signalIndex;
-
-    button->originalPos = definition->location;
     button->cubeSignalIndex = definition->cubeSignalIndex;
+    button->deactivateSignalIndex = definition->deactivateSignalIndex;
+    button->originalPos = definition->location;
     button->flags = 0;
-
+    
+    button->pressFrames = CUBE_PRESS_IDLE_FRAMES;
+    
     dynamicSceneSetRoomFlags(button->dynamicId, ROOM_FLAG_FROM_INDEX(button->rigidBody.currentRoom));
 }
 
 void buttonUpdate(struct Button* button) {
     struct ContactManifold* manifold = contactSolverNextManifold(&gContactSolver, &button->collisionObject, NULL);
+    
+    int deactivated = signalsRead(button->deactivateSignalIndex);
+    if (!deactivated) {
+        int shouldPress = 0;
+        while (manifold) {
+            struct CollisionObject* other = manifold->shapeA == &button->collisionObject ? manifold->shapeB : manifold->shapeA;
 
-    int shouldPress = 0;
-    while (manifold) {
-        struct CollisionObject* other = manifold->shapeA == &button->collisionObject ? manifold->shapeB : manifold->shapeA;
+            if (other->body && other->body->mass > MASS_BUTTON_PRESS_THRESHOLD) {
+                
+                shouldPress = 1;
 
-        if (other->body && other->body->mass > MASS_BUTTON_PRESS_THRESHOLD) {
+                if ((other->body->flags & RigidBodyFlagsGrabbable) == RigidBodyFlagsGrabbable && button->pressFrames <= 0) {
+                    shouldPress = PRESSED_WITH_CUBE;
+                }
+                
+                break;
+            }
             
+            manifold = contactSolverNextManifold(&gContactSolver, &button->collisionObject, manifold);
+        }
+    
+        if (button->collisionObject.flags & COLLISION_OBJECT_PLAYER_STANDING) {
+            button->collisionObject.flags &= ~COLLISION_OBJECT_PLAYER_STANDING;
             shouldPress = 1;
-
-            if ((other->body->flags & RigidBodyFlagsGrabbable) == RigidBodyFlagsGrabbable && (other->body->sleepFrames <= IDLE_SLEEP_FRAMES - 2)) {
-                shouldPress = PRESSED_WITH_CUBE;
-            }
-
-            break;
         }
-
-        manifold = contactSolverNextManifold(&gContactSolver, &button->collisionObject, manifold);
-    }
-    
-
-    if (button->collisionObject.flags & COLLISION_OBJECT_PLAYER_STANDING) {
-        button->collisionObject.flags &= ~COLLISION_OBJECT_PLAYER_STANDING;
-        shouldPress = 1;
-    }
-
-    struct Vector3 targetPos = button->originalPos;
-    
-    if (shouldPress) {
         
+        struct Vector3 targetPos = button->originalPos;
         
-        targetPos.y -= BUTTON_MOVEMENT_AMOUNT;
-        signalsSend(button->signalIndex);
+        if (shouldPress) {
+            targetPos.y -= BUTTON_MOVEMENT_AMOUNT;
+            signalsSend(button->signalIndex);
 
-        if (shouldPress == PRESSED_WITH_CUBE) {
-            signalsSend(button->cubeSignalIndex);
+            if (shouldPress == PRESSED_WITH_CUBE) {
+                signalsSend(button->cubeSignalIndex);
+            }
+            
+            if (button->pressFrames > 0) {
+                --button->pressFrames;
+            }
+        } else {
+            button->pressFrames = CUBE_PRESS_IDLE_FRAMES;
+        }
+        
+        //if its actively moving up or down
+        if (targetPos.y != button->rigidBody.transform.position.y) {
+            //actively going down
+            if (shouldPress) {
+                if (!(button->flags & ButtonFlagsBeingPressed)) {
+                    soundPlayerPlay(soundsButton, 2.5f, 0.5f, &button->rigidBody.transform.position, &gZeroVec, SoundTypeAll);
+                    hudShowSubtitle(&gScene.hud, PORTAL_BUTTON_DOWN, SubtitleTypeCaption);
+                }
+                button->flags |= ButtonFlagsBeingPressed;
+            }
+            // actively going up
+            else {
+                if ((button->flags & ButtonFlagsBeingPressed)) {
+                    soundPlayerPlay(soundsButtonRelease, 2.5f, 0.4f, &button->rigidBody.transform.position, &gZeroVec, SoundTypeAll);
+                    hudShowSubtitle(&gScene.hud, PORTAL_BUTTON_UP, SubtitleTypeCaption);
+                }
+                button->flags &= ~ButtonFlagsBeingPressed;
+            }
+
+            vector3MoveTowards(&button->rigidBody.transform.position, &targetPos, BUTTON_MOVE_VELOCTY * FIXED_DELTA_TIME, &button->rigidBody.transform.position);
+            collisionObjectUpdateBB(&button->collisionObject);
         }
     }
-
-    //if its actively moving up or down
-    if (targetPos.y != button->rigidBody.transform.position.y) {
-        //actively going down
-        if (shouldPress){
-            if (!(button->flags & ButtonFlagsBeingPressed)){
-                soundPlayerPlay(soundsButton, 2.5f, 0.5f, &button->rigidBody.transform.position, &gZeroVec, SoundTypeAll);
-                hudShowSubtitle(&gScene.hud, PORTAL_BUTTON_DOWN, SubtitleTypeCaption);
-            }
-            button->flags |= ButtonFlagsBeingPressed;
-        }
-        // actively going up
-        else{
-            if ((button->flags & ButtonFlagsBeingPressed)){
-                soundPlayerPlay(soundsButtonRelease, 2.5f, 0.4f, &button->rigidBody.transform.position, &gZeroVec, SoundTypeAll);
-                hudShowSubtitle(&gScene.hud, PORTAL_BUTTON_UP, SubtitleTypeCaption);
-            }
-            button->flags &= ~ButtonFlagsBeingPressed;
-        }
-
-        vector3MoveTowards(&button->rigidBody.transform.position, &targetPos, BUTTON_MOVE_VELOCTY * FIXED_DELTA_TIME, &button->rigidBody.transform.position);
-        collisionObjectUpdateBB(&button->collisionObject);
-    }
-    
 }

--- a/src/scene/button.h
+++ b/src/scene/button.h
@@ -17,8 +17,10 @@ struct Button {
     short dynamicId;
     short signalIndex;
     short cubeSignalIndex;
+    short deactivateSignalIndex;
     struct Vector3 originalPos;
     short flags;
+    short pressFrames;
 };
 
 void buttonInit(struct Button* button, struct ButtonDefinition* definition);

--- a/tools/level_scripts/entities.lua
+++ b/tools/level_scripts/entities.lua
@@ -35,6 +35,7 @@ for _, button in pairs(sk_scene.nodes_for_type('@button')) do
         room_index,
         signals.signal_index_for_name(button.arguments[1] or ''),
         signals.signal_index_for_name(button.arguments[2] or ''),
+        signals.signal_index_for_name(button.arguments[3] or ''),
     })
 end
 


### PR DESCRIPTION
See Issue #17 

As of now, this would enable to deactivate buttons for "escape hatch" cutscenes in Chamber04, Chamber13 and Chamber14.

In those chambers, the relevant button objects in the blender files would simply need to be renamed to something like:
```
@button open_door open_door_cube escape_hatch
```
(At the example of the button in chamber14).