### PR TITLE
Serialize / deserialize detached security cameras in savegames

### DIFF
--- a/src/savefile/scene_serialize.c
+++ b/src/savefile/scene_serialize.c
@@ -463,7 +463,7 @@ void securityCameraSerialize(struct Serializer* serializer, SerializeAction acti
     
     for (int i = 0; i < scene->securityCameraCount; ++i) {
         struct SecurityCamera* cam = &scene->securityCameras[i];
-        if (!(cam->rigidBody.flags & RigidBodyIsKinematic)) {
+        if (securityCameraIsDetached(cam)) {
             u8 index = i;
             action(serializer, &index, sizeof(u8));
             
@@ -492,7 +492,7 @@ void securityCameraDeserialize(struct Serializer* serializer, struct Scene* scen
         
         struct SecurityCamera* cam = &scene->securityCameras[index];
         
-        rigidBodyUnmarkKinematic(&cam->rigidBody, SECURITY_CAMERA_RIGID_BODY_MASS, securityCameraMofI());
+        securityCameraDetach(cam);
         
         serializeRead(serializer, &cam->rigidBody.transform, sizeof(struct PartialTransform));
         serializeRead(serializer, &cam->rigidBody.velocity, sizeof(struct Vector3));

--- a/src/savefile/scene_serialize.c
+++ b/src/savefile/scene_serialize.c
@@ -451,7 +451,7 @@ void securityCameraSerialize(struct Serializer* serializer, SerializeAction acti
     short heldCam = -1;
     for (int i = 0; i < scene->securityCameraCount; ++i) {
         struct SecurityCamera* cam = &scene->securityCameras[i];
-        if (!(cam->rigidBody.flags & RigidBodyIsKinematic)) {
+        if (securityCameraIsDetached(cam)) {
             if (&cam->collisionObject == scene->player.grabConstraint.object) {
                 heldCam = serializedCount;
             }

--- a/src/savefile/scene_serialize.c
+++ b/src/savefile/scene_serialize.c
@@ -319,7 +319,6 @@ void launcherSerialize(struct Serializer* serializer, SerializeAction action, st
         action(serializer, &launcher->currentBall.targetSpeed, sizeof(float));
         action(serializer, &launcher->currentBall.flags, sizeof(short));
 
-
         if (!ballIsActive(&launcher->currentBall) || ballIsCaught(&launcher->currentBall)) {
             continue;
         }
@@ -447,9 +446,72 @@ void sceneAnimatorDeserialize(struct Serializer* serializer, struct Scene* scene
     }
 }
 
-#define INCLUDE_SAVEFILE_ALIGH_CHECKS   0
+void securityCameraSerialize(struct Serializer* serializer, SerializeAction action, struct Scene* scene) {
+    u8 serializedCount = 0;
+    short heldCam = -1;
+    for (int i = 0; i < scene->securityCameraCount; ++i) {
+        struct SecurityCamera* cam = &scene->securityCameras[i];
+        if (!(cam->rigidBody.flags & RigidBodyIsKinematic)) {
+            if (&cam->collisionObject == scene->player.grabConstraint.object) {
+                heldCam = serializedCount;
+            }
+            ++serializedCount;
+        }
+    }
+    action(serializer, &serializedCount, sizeof(u8));
+    action(serializer, &heldCam, sizeof(short));
+    
+    for (int i = 0; i < scene->securityCameraCount; ++i) {
+        struct SecurityCamera* cam = &scene->securityCameras[i];
+        if (!(cam->rigidBody.flags & RigidBodyIsKinematic)) {
+            u8 index = i;
+            action(serializer, &index, sizeof(u8));
+            
+            action(serializer, &cam->rigidBody.transform, sizeof(struct PartialTransform));
+            action(serializer, &cam->rigidBody.velocity, sizeof(struct Vector3));
+            action(serializer, &cam->rigidBody.angularVelocity, sizeof(struct Vector3));
+            action(serializer, &cam->rigidBody.flags, sizeof(enum RigidBodyFlags));
+            action(serializer, &cam->rigidBody.currentRoom, sizeof(short));
+        }
+    }
+}
 
-#if INCLUDE_SAVEFILE_ALIGH_CHECKS
+void securityCameraDeserialize(struct Serializer* serializer, struct Scene* scene) {
+    u8 serializedCount;
+    serializeRead(serializer, &serializedCount, sizeof(u8));
+    
+    short heldCam;
+    serializeRead(serializer, &heldCam, sizeof(short));
+    
+    for (int i = 0; i < serializedCount; ++i) {
+        u8 index;
+        serializeRead(serializer, &index, sizeof(u8));
+        if (index >= scene->securityCameraCount) {
+            continue;
+        }
+        
+        struct SecurityCamera* cam = &scene->securityCameras[index];
+        
+        rigidBodyUnmarkKinematic(&cam->rigidBody, SECURITY_CAMERA_RIGID_BODY_MASS, securityCameraMofI());
+        
+        serializeRead(serializer, &cam->rigidBody.transform, sizeof(struct PartialTransform));
+        serializeRead(serializer, &cam->rigidBody.velocity, sizeof(struct Vector3));
+        serializeRead(serializer, &cam->rigidBody.angularVelocity, sizeof(struct Vector3));
+        serializeRead(serializer, &cam->rigidBody.flags, sizeof(enum RigidBodyFlags));
+        serializeRead(serializer, &cam->rigidBody.currentRoom, sizeof(short));
+        
+        cam->rigidBody.flags &= ~RigidBodyIsSleeping;
+        cam->rigidBody.sleepFrames = IDLE_SLEEP_FRAMES;
+
+        if (heldCam == i) {
+            playerSetGrabbing(&scene->player, &cam->collisionObject);
+        }
+    }
+}
+
+#define INCLUDE_SAVEFILE_ALIGN_CHECKS   0
+
+#if INCLUDE_SAVEFILE_ALIGN_CHECKS
 #define WRITE_ALIGN_CHECK   {action(serializer, &currentAlign, 1); ++currentAlign;}
 #define READ_ALIGN_CHECK {serializeRead(serializer, &currentAlign, 1); if (currentAlign != expectedAlign) gdbBreak(); ++expectedAlign;}
 #else
@@ -458,7 +520,7 @@ void sceneAnimatorDeserialize(struct Serializer* serializer, struct Scene* scene
 #endif
 
 void sceneSerialize(struct Serializer* serializer, SerializeAction action, struct Scene* scene) {
-#if INCLUDE_SAVEFILE_ALIGH_CHECKS
+#if INCLUDE_SAVEFILE_ALIGN_CHECKS
     char currentAlign = 0;
 #endif
     playerSerialize(serializer, action, &scene->player);
@@ -485,10 +547,12 @@ void sceneSerialize(struct Serializer* serializer, SerializeAction action, struc
     WRITE_ALIGN_CHECK;
     switchSerialize(serializer, action, scene);
     WRITE_ALIGN_CHECK;
+    securityCameraSerialize(serializer, action, scene);
+    WRITE_ALIGN_CHECK;
 }
 
 void sceneDeserialize(struct Serializer* serializer, struct Scene* scene) {
-#if INCLUDE_SAVEFILE_ALIGH_CHECKS
+#if INCLUDE_SAVEFILE_ALIGN_CHECKS
     char currentAlign = 0;
     char expectedAlign = 0;
 #endif
@@ -515,6 +579,8 @@ void sceneDeserialize(struct Serializer* serializer, struct Scene* scene) {
     sceneAnimatorDeserialize(serializer, scene);
     READ_ALIGN_CHECK;
     switchSerialize(serializer, serializeRead, scene);
+    READ_ALIGN_CHECK;
+    securityCameraDeserialize(serializer, scene);
     READ_ALIGN_CHECK;
 
     for (int i = 0; i < scene->doorCount; ++i) {

--- a/src/scene/security_camera.c
+++ b/src/scene/security_camera.c
@@ -168,7 +168,7 @@ void securityCamerasCheckPortal(struct SecurityCamera* securityCameras, int came
             continue;
         }
         if (box3DHasOverlap(&camera->collisionObject.boundingBox, portalBox)) {
-            rigidBodyUnmarkKinematic(&camera->rigidBody, 1.0f, collisionBoxSolidMofI(&gSecurityCameraCollider, 1.0f));
+            rigidBodyUnmarkKinematic(&camera->rigidBody, SECURITY_CAMERA_RIGID_BODY_MASS, securityCameraMofI());
             camera->collisionObject.collisionLayers |= COLLISION_LAYERS_GRABBABLE;
             camera->rigidBody.flags |= RigidBodyFlagsGrabbable;
 
@@ -178,4 +178,8 @@ void securityCamerasCheckPortal(struct SecurityCamera* securityCameras, int came
             }
         }
     }
+}
+
+float securityCameraMofI() {
+    return collisionBoxSolidMofI(&gSecurityCameraCollider, SECURITY_CAMERA_RIGID_BODY_MASS);
 }

--- a/src/scene/security_camera.c
+++ b/src/scene/security_camera.c
@@ -33,7 +33,7 @@ struct ColliderTypeData gSecurityCameraCollider = {
 struct Quaternion gBarBoneRelative = {1.0f, 0.0f, 0.0f, 0.0f};
 
 void securityCameraLookAt(struct SecurityCamera* camera, struct Vector3* target) {
-    if (!(camera->rigidBody.flags & RigidBodyIsKinematic)) {
+    if (securityCameraIsDetached(camera)) {
         return;
     }
 
@@ -164,7 +164,7 @@ short gCameraDestroyClips[] = {
 void securityCamerasCheckPortal(struct SecurityCamera* securityCameras, int cameraCount, struct Box3D* portalBox) {
     for (int i = 0; i < cameraCount; ++i) {
         struct SecurityCamera* camera = &securityCameras[i];
-        if (!(camera->rigidBody.flags & RigidBodyIsKinematic)) {
+        if (securityCameraIsDetached(camera)) {
             // already free skip this one
             continue;
         }

--- a/src/scene/security_camera.h
+++ b/src/scene/security_camera.h
@@ -5,6 +5,8 @@
 #include "../levels/level_definition.h"
 #include "../sk64/skelatool_armature.h"
 
+#define SECURITY_CAMERA_RIGID_BODY_MASS 1.0f
+
 struct SecurityCamera {
     struct CollisionObject collisionObject;
     struct RigidBody rigidBody;
@@ -17,5 +19,7 @@ void securityCameraInit(struct SecurityCamera* securityCamera, struct SecurityCa
 void securityCameraUpdate(struct SecurityCamera* securityCamera);
 
 void securityCamerasCheckPortal(struct SecurityCamera* securityCameras, int cameraCount, struct Box3D* portalBox);
+
+float securityCameraMofI(); // utility for serialization
 
 #endif

--- a/src/scene/security_camera.h
+++ b/src/scene/security_camera.h
@@ -5,8 +5,6 @@
 #include "../levels/level_definition.h"
 #include "../sk64/skelatool_armature.h"
 
-#define SECURITY_CAMERA_RIGID_BODY_MASS 1.0f
-
 struct SecurityCamera {
     struct CollisionObject collisionObject;
     struct RigidBody rigidBody;
@@ -20,6 +18,7 @@ void securityCameraUpdate(struct SecurityCamera* securityCamera);
 
 void securityCamerasCheckPortal(struct SecurityCamera* securityCameras, int cameraCount, struct Box3D* portalBox);
 
-float securityCameraMofI(); // utility for serialization
+void securityCameraDetach();
+int securityCameraIsDetached();
 
 #endif


### PR DESCRIPTION
Fix for Issue #25

Some minor changes to security_camera code to make this optimal in terms of memory:
* Rigid body mass was previously hardcoded as `1.0f` in `security_camera.c`, this was replaced with the definition `SECURITY_CAMERA_RIGID_BODY_MASS`.
* New public utility function `float securityCameraMofI()` which calculates the moment of inertia for security cameras. 
* Both mass and moment of inertia are identical for each security camera and were needed to be accessible in `scene_serialize.c` for deserializing, due to `rigidBodyMarkKinematic()`.