### PR TITLE
Keep grabbed objects in front of player

### DIFF
--- a/src/player/player.h
+++ b/src/player/player.h
@@ -41,6 +41,7 @@ struct Player {
     short grabbingThroughPortal;
     short dynamicId;
     struct PointConstraint grabConstraint;
+    struct Quaternion grabRotationBase;
     float pitchVelocity;
     float yawVelocity;
     enum PlayerFlags flags;

--- a/src/savefile/scene_serialize.c
+++ b/src/savefile/scene_serialize.c
@@ -14,6 +14,7 @@ void playerSerialize(struct Serializer* serializer, SerializeAction action, stru
     action(serializer, &player->body.velocity, sizeof(player->body.velocity));
     action(serializer, &player->body.currentRoom, sizeof(player->body.currentRoom));
     action(serializer, &player->flags, sizeof(player->flags));
+    action(serializer, &player->grabbingThroughPortal, sizeof(player->grabbingThroughPortal));
 }
 
 void playerDeserialize(struct Serializer* serializer, struct Player* player) {
@@ -22,6 +23,7 @@ void playerDeserialize(struct Serializer* serializer, struct Player* player) {
     serializeRead(serializer, &player->body.velocity, sizeof(player->body.velocity));
     serializeRead(serializer, &player->body.currentRoom, sizeof(player->body.currentRoom));
     serializeRead(serializer, &player->flags, sizeof(player->flags));
+    serializeRead(serializer, &player->grabbingThroughPortal, sizeof(player->grabbingThroughPortal));
 }
 
 #define PORTAL_FLAGS_NO_PORTAL  -1


### PR DESCRIPTION
See Issue #27

Grabbed objects now remain at a constant distance from the player on the XZ-plane (ground plane). Effectively, the object now moves along a straight upward line in worldspace when the player looks up or down. The target height (Y component) of the object is calculated the same way as before, which I found also has a nice smoothing effect on the up-/downward object movement due to the implied projection.

Additionally, grabbed objects are now no longer rotated towards the player. The original rotation of the object relative to the player's looking direction (on the XZ plane) is maintained while grabbing, the same way as in original Portal.

Lastly, I fixed a minor bug along the way, which caused objects to be let go of when loading a savegame. This occurred when the object was held through a portal, such that `player->grabbingThroughPortal != 0`.


https://github.com/mwpenny/portal64-still-alive/assets/2451901/80792353-cdf9-478b-ab4c-2002032ed258