### PR TITLE
Dont fire portal with grabbed object or from pause menu

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -54,7 +54,7 @@
 #define MAX_ROTATE_RATE_DELTA MAX_ROTATE_RATE
 
 #define JUMP_IMPULSE   2.7f
-#define THROW_IMPULSE  2.7f
+#define THROW_IMPULSE  1.35f
 
 struct Vector3 gGrabDistance = {0.0f, 0.0f, -1.5f};
 struct Vector3 gCameraOffset = {0.0f, 0.0f, 0.0f};
@@ -307,7 +307,8 @@ void playerThrowObject(struct Player* player) {
     struct Vector3 forward, right;
     playerGetMoveBasis(&player->lookTransform, &forward, &right);
     
-    vector3Scale(&forward, &forward, -1.0f * THROW_IMPULSE);
+    // scale impulse with mass to throw each object the same distance
+    vector3Scale(&forward, &forward, -1.0f * THROW_IMPULSE * object->body->mass);
     rigidBodyAppyImpulse(object->body, &object->body->transform.position, &forward);
 }
 

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -54,6 +54,7 @@
 #define MAX_ROTATE_RATE_DELTA MAX_ROTATE_RATE
 
 #define JUMP_IMPULSE   2.7f
+#define THROW_IMPULSE  2.7f
 
 struct Vector3 gGrabDistance = {0.0f, 0.0f, -1.5f};
 struct Vector3 gCameraOffset = {0.0f, 0.0f, 0.0f};
@@ -294,6 +295,20 @@ void playerSignalPortalChanged(struct Player* player) {
 
 int playerIsGrabbing(struct Player* player) {
     return player->grabConstraint.object != NULL;
+}
+
+void playerThrowObject(struct Player* player) {
+    if (!playerIsGrabbing(player)) {
+        return;
+    }
+    struct CollisionObject* object = player->grabConstraint.object;
+    playerSetGrabbing(player, NULL);
+    
+    struct Vector3 forward, right;
+    playerGetMoveBasis(&player->lookTransform, &forward, &right);
+    
+    vector3Scale(&forward, &forward, -1.0f * THROW_IMPULSE);
+    rigidBodyAppyImpulse(object->body, &object->body->transform.position, &forward);
 }
 
 int playerRaycastGrab(struct Player* player, struct RaycastHit* hit, int checkPastObject) {

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -73,6 +73,7 @@ int playerIsDead(struct Player* player);
 void playerSetGrabbing(struct Player* player, struct CollisionObject* grabbing);
 void playerSignalPortalChanged(struct Player* player);
 int playerIsGrabbing(struct Player* player);
+void playerThrowObject(struct Player* player);
 
 void playerSerialize(struct Serializer* serializer, SerializeAction action, struct Player* player);
 void playerDeserialize(struct Serializer* serializer, struct Player* player);

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -411,7 +411,7 @@ void sceneCheckPortals(struct Scene* scene) {
     }
 
     if ((fireOrange || fireBlue) && playerIsGrabbing(&scene->player)){
-        playerSetGrabbing(&scene->player, NULL);
+        playerThrowObject(&scene->player);
         scene->ignorePortalGun = fireOrange && fireBlue ? IGNORE_FIRE_BOTH : (fireBlue ? IGNORE_FIRE_BLUE : IGNORE_FIRE_ORANGE); // prevent blocking other button
     }
     

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -53,6 +53,10 @@ Lights1 gSceneLights = gdSPDefLights1(128, 128, 128, 128, 128, 128, 0, 127, 0);
 #define LEVEL_INDEX_WITH_GUN_0  2
 #define LEVEL_INDEX_WITH_GUN_1  8
 
+#define IGNORE_FIRE_BOTH 1
+#define IGNORE_FIRE_BLUE 2
+#define IGNORE_FIRE_ORANGE 3
+
 void sceneUpdateListeners(struct Scene* scene);
 
 void sceneInitDynamicColliders(struct Scene* scene) {
@@ -370,8 +374,12 @@ void sceneCheckPortals(struct Scene* scene) {
     int fireBlue = controllerActionGet(ControllerActionOpenPortal0);
     int fireOrange = controllerActionGet(ControllerActionOpenPortal1);
 
-    // this prevents the firing of portals after unpausing
-    if (scene->ignorePortalGun && (fireBlue || fireOrange)) {
+    // this prevents the firing of portals after unpausing or dropping an object
+    if (scene->ignorePortalGun == IGNORE_FIRE_BLUE && fireBlue) {
+        fireBlue = 0;
+    } else if (scene->ignorePortalGun == IGNORE_FIRE_ORANGE && fireOrange) {
+        fireOrange = 0;
+    } else if (scene->ignorePortalGun == IGNORE_FIRE_BOTH && (fireBlue || fireOrange)) {
         fireBlue = 0;
         fireOrange = 0;
     } else {
@@ -404,6 +412,7 @@ void sceneCheckPortals(struct Scene* scene) {
 
     if ((fireOrange || fireBlue) && playerIsGrabbing(&scene->player)){
         playerSetGrabbing(&scene->player, NULL);
+        scene->ignorePortalGun = fireOrange && fireBlue ? IGNORE_FIRE_BOTH : (fireBlue ? IGNORE_FIRE_BLUE : IGNORE_FIRE_ORANGE); // prevent blocking other button
     }
     
     if ((scene->player.flags & PlayerFlagsGrounded) && (scene->player.flags & PlayerIsStepping)){

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -86,7 +86,6 @@ struct Scene {
 
     u8 continuouslyAttemptingPortalOpen;
     u8 checkpointState;
-    u8 ignorePortalGun;
 };
 
 extern struct Scene gScene;


### PR DESCRIPTION
See Issues #23 & #26.

To prevent the portalgun from firing when dropping a grabbed object via portal buttons, I used the pre-existing variable `scene->ignorePortalGun`. Now, the pressed portal button needs to be released prior to being used again. I also extended the connected logic a bit to prevent blocking the other button in the next frame(s) (if the other button is pressed in the next frame, it would otherwise block the entire press). Working on this I subsequently also fixed firing portals when exiting pause menu, as this was closely related.

Also, I noticed the "throw" impulse when pressing the portal buttons was not yet implemented, so I added it. I tried to get the impulse to match the original Portal and using the same value as the player's `JUMP_IMPULSE` worked really well. Coincidence? Who knows.

Edit: Throw impulse now scales with mass of the object, so the throw distance is consistent even with cameras and radios.

https://github.com/mwpenny/portal64-still-alive/assets/2451901/6e138323-cee0-4f59-85f3-759266f9df33

https://github.com/mwpenny/portal64-still-alive/assets/2451901/2cb354ff-a302-45dd-bc4e-a7ca681f160a