### PR TITLE
Throw direction fix when grabbing through portal

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -301,18 +301,12 @@ void playerThrowObject(struct Player* player) {
     if (!playerIsGrabbing(player)) {
         return;
     }
-    struct Transform lookTransform = player->lookTransform;
-    if (player->grabbingThroughPortal != PLAYER_GRABBING_THROUGH_NOTHING) {
-        struct Transform pointTransform;
-        collisionSceneGetPortalTransform(player->grabbingThroughPortal > 0 ? 0 : 1, &pointTransform);
-        for (int i = 0; i < abs(player->grabbingThroughPortal); ++i) {
-            struct Quaternion finalRotation;
-            quatMultiply(&pointTransform.rotation, &lookTransform.rotation, &finalRotation);
-            lookTransform.rotation = finalRotation;
-        }
-    }
+
+    struct Transform throwTransform = player->lookTransform;
+    playerPortalGrabTransform(player, &throwTransform.position, &throwTransform.rotation);
+
     struct Vector3 forward, right;
-    playerGetMoveBasis(&lookTransform, &forward, &right);
+    playerGetMoveBasis(&throwTransform, &forward, &right);
     
     struct CollisionObject* object = player->grabConstraint.object;
     playerSetGrabbing(player, NULL);
@@ -439,15 +433,7 @@ void playerUpdateGrabbedObject(struct Player* player) {
                 return;
             }
 
-            struct Transform pointTransform;
-            collisionSceneGetPortalTransform(player->grabbingThroughPortal > 0 ? 0 : 1, &pointTransform);
-
-            for (int i = 0; i < abs(player->grabbingThroughPortal); ++i) {
-                transformPoint(&pointTransform, &grabPoint, &grabPoint);
-                struct Quaternion finalRotation;
-                quatMultiply(&pointTransform.rotation, &grabRotation, &finalRotation);
-                grabRotation = finalRotation;
-            }
+            playerPortalGrabTransform(player, &grabPoint, &grabRotation);
         }
 
         pointConstraintUpdateTarget(&player->grabConstraint, &grabPoint, &grabRotation);
@@ -470,6 +456,22 @@ void playerGetMoveBasis(struct Transform* transform, struct Vector3* forward, st
 
     vector3Normalize(forward, forward);
     vector3Normalize(right, right);
+}
+
+void playerPortalGrabTransform(struct Player* player, struct Vector3* grabPoint, struct Quaternion* grabRotation) {
+    if (player->grabbingThroughPortal == PLAYER_GRABBING_THROUGH_NOTHING) {
+        return;
+    }
+
+    struct Transform pointTransform;
+    collisionSceneGetPortalTransform(player->grabbingThroughPortal > 0 ? 0 : 1, &pointTransform);
+
+    for (int i = 0; i < abs(player->grabbingThroughPortal); ++i) {
+        transformPoint(&pointTransform, grabPoint, grabPoint);
+        struct Quaternion finalRotation;
+        quatMultiply(&pointTransform.rotation, grabRotation, &finalRotation);
+        *grabRotation = finalRotation;
+    }
 }
 
 void playerGivePortalGun(struct Player* player, int flags) {

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -301,11 +301,21 @@ void playerThrowObject(struct Player* player) {
     if (!playerIsGrabbing(player)) {
         return;
     }
+    struct Transform lookTransform = player->lookTransform;
+    if (player->grabbingThroughPortal != PLAYER_GRABBING_THROUGH_NOTHING) {
+        struct Transform pointTransform;
+        collisionSceneGetPortalTransform(player->grabbingThroughPortal > 0 ? 0 : 1, &pointTransform);
+        for (int i = 0; i < abs(player->grabbingThroughPortal); ++i) {
+            struct Quaternion finalRotation;
+            quatMultiply(&pointTransform.rotation, &lookTransform.rotation, &finalRotation);
+            lookTransform.rotation = finalRotation;
+        }
+    }
+    struct Vector3 forward, right;
+    playerGetMoveBasis(&lookTransform, &forward, &right);
+    
     struct CollisionObject* object = player->grabConstraint.object;
     playerSetGrabbing(player, NULL);
-    
-    struct Vector3 forward, right;
-    playerGetMoveBasis(&player->lookTransform, &forward, &right);
     
     // scale impulse with mass to throw each object the same distance
     vector3Scale(&forward, &forward, -1.0f * THROW_IMPULSE * object->body->mass);

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -64,6 +64,7 @@ void playerUpdateFooting(struct Player* player, float maxStandDistance);
 void playerApplyCameraTransform(struct Player* player, struct Transform* cameraTransform);
 
 void playerGetMoveBasis(struct Transform* transform, struct Vector3* forward, struct Vector3* right);
+void playerPortalGrabTransform(struct Player* player, struct Vector3* point, struct Quaternion* rotation);
 
 void playerGivePortalGun(struct Player* player, int flags);
 


### PR DESCRIPTION
This is a post hoc fix for PR #32.
Unfortunately I only noticed this bug today while testing multiple different cases of portal behavior with grabbed objects for #27.

Before the fix supplied here, the throw direction is incorrect when throwing an object that is held through a portal (if the portals effectively apply a worldspace rotation). In the video below, the behavior before and then after the fix is showcased.

https://github.com/mwpenny/portal64-still-alive/assets/2451901/1accc131-9a18-401a-8272-2d9e4a45ce09