### PR TITLE
Keep grabbed objects in front of player & savegame grab through portals fix

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -423,7 +423,6 @@ void playerUpdateGrabbedObject(struct Player* player) {
         vector3Multiply(&player->lookTransform.scale, &temp_grab_dist, &temp_grab_dist);
         
         struct Vector3 grabPoint;
-        struct Quaternion grabRotation = player->lookTransform.rotation;
         
         // determine object target height
         quatMultVector(&player->lookTransform.rotation, &temp_grab_dist, &grabPoint);
@@ -438,6 +437,8 @@ void playerUpdateGrabbedObject(struct Player* player) {
         quatMultVector(&forwardRotation, &temp_grab_dist, &grabPoint);
         vector3Add(&player->lookTransform.position, &grabPoint, &grabPoint);
         grabPoint.y += grabY;
+        
+        struct Quaternion grabRotation = forwardRotation;
         
         if (player->grabbingThroughPortal != PLAYER_GRABBING_THROUGH_NOTHING) {
             if (!collisionSceneIsPortalOpen()) {

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -406,9 +406,6 @@ void playerUpdateGrabbedObject(struct Player* player) {
             playerApplyPortalGrab(player, 1);
         }
 
-        struct Vector3 grabPoint;
-        struct Quaternion grabRotation = player->lookTransform.rotation;
-
         // try to determine how far away to set the grab dist
         struct RaycastHit hit;
         struct Vector3 temp_grab_dist = gGrabDistance;
@@ -423,9 +420,25 @@ void playerUpdateGrabbedObject(struct Player* player) {
             playerSetGrabbing(player, NULL);
             return;
         }
-
-        transformPoint(&player->lookTransform, &temp_grab_dist, &grabPoint);
-
+        vector3Multiply(&player->lookTransform.scale, &temp_grab_dist, &temp_grab_dist);
+        
+        struct Vector3 grabPoint;
+        struct Quaternion grabRotation = player->lookTransform.rotation;
+        
+        // determine object target height
+        quatMultVector(&player->lookTransform.rotation, &temp_grab_dist, &grabPoint);
+        float grabY = grabPoint.y;
+//
+        // keep object at steady XZ-planar distance in front of player
+        struct Quaternion forwardRotation;
+        struct Vector3 forward, forwardNegate, right;
+        playerGetMoveBasis(&player->lookTransform, &forward, &right);
+        vector3Negate(&forward, &forwardNegate);
+        quatLook(&forwardNegate, &gUp, &forwardRotation);
+        quatMultVector(&forwardRotation, &temp_grab_dist, &grabPoint);
+        vector3Add(&player->lookTransform.position, &grabPoint, &grabPoint);
+        grabPoint.y += grabY;
+        
         if (player->grabbingThroughPortal != PLAYER_GRABBING_THROUGH_NOTHING) {
             if (!collisionSceneIsPortalOpen()) {
                 // portal was closed while holding object through it

--- a/src/savefile/scene_serialize.c
+++ b/src/savefile/scene_serialize.c
@@ -14,6 +14,7 @@ void playerSerialize(struct Serializer* serializer, SerializeAction action, stru
     action(serializer, &player->body.velocity, sizeof(player->body.velocity));
     action(serializer, &player->body.currentRoom, sizeof(player->body.currentRoom));
     action(serializer, &player->flags, sizeof(player->flags));
+    action(serializer, &player->grabbingThroughPortal, sizeof(player->grabbingThroughPortal));
 }
 
 void playerDeserialize(struct Serializer* serializer, struct Player* player) {
@@ -22,6 +23,7 @@ void playerDeserialize(struct Serializer* serializer, struct Player* player) {
     serializeRead(serializer, &player->body.velocity, sizeof(player->body.velocity));
     serializeRead(serializer, &player->body.currentRoom, sizeof(player->body.currentRoom));
     serializeRead(serializer, &player->flags, sizeof(player->flags));
+    serializeRead(serializer, &player->grabbingThroughPortal, sizeof(player->grabbingThroughPortal));
 }
 
 #define PORTAL_FLAGS_NO_PORTAL  -1


### PR DESCRIPTION
Just the code relevant for Issue #27 from PR #31 (plus the minor bug fix for savegames and grabbing through portals). 

Independent of the discussion in #31, even when keeping the behavior of rotating grabbed objects towards the player, I'd still propose to only rotate the objects towards the "forward" direction, not the lookTransform direction (see videos below). This will make placing cubes on surfaces above or below the player easier. Also, this could easily be enabled only for cubes and not for other props.

This is not implemented here, but can be achieved by changing a single line of code:

```
struct Quaternion grabRotation = player->lookTransform.rotation;
```

to

```
struct Quaternion grabRotation = forwardRotation;
```
(In player.c line 426).


https://github.com/mwpenny/portal64-still-alive/assets/2451901/d0188593-f632-451b-bec4-bb9dbe2ef363


https://github.com/mwpenny/portal64-still-alive/assets/2451901/06eb5868-18a9-44fd-9a82-5f0cfc127ff6

