### PR TITLE
Encapsulate looking up a decorId from CollisionObjects

### DIFF
--- a/src/decor/decor_object_list.c
+++ b/src/decor/decor_object_list.c
@@ -237,3 +237,7 @@ int decorIdForObjectDefinition(struct DecorObjectDefinition* def) {
 
     return result;
 }
+
+int decorIdForCollisionObject(struct CollisionObject* collisionObject) {
+    return decorIdForObjectDefinition((struct DecorObjectDefinition*)collisionObject->collider);
+}

--- a/src/decor/decor_object_list.h
+++ b/src/decor/decor_object_list.h
@@ -19,4 +19,6 @@
 struct DecorObjectDefinition* decorObjectDefinitionForId(int id);
 int decorIdForObjectDefinition(struct DecorObjectDefinition* def);
 
+int decorIdForCollisionObject(struct CollisionObject* collisionObject); // evil hack
+
 #endif

--- a/src/scene/fizzler.c
+++ b/src/scene/fizzler.c
@@ -26,7 +26,7 @@ void fizzlerTrigger(void* data, struct CollisionObject* objectEnteringTrigger) {
     }
 
     if (fizzler->cubeSignalIndex != -1) {
-        int decorType = decorIdForObjectDefinition((struct DecorObjectDefinition*)objectEnteringTrigger->collider);
+        int decorType = decorIdForCollisionObject(objectEnteringTrigger);
         if (decorType == DECOR_TYPE_CUBE || decorType == DECOR_TYPE_CUBE_UNIMPORTANT) {
             signalsSend(fizzler->cubeSignalIndex);
         }

--- a/src/scene/trigger_listener.c
+++ b/src/scene/trigger_listener.c
@@ -15,8 +15,7 @@ enum ObjectTriggerType triggerDetermineType(struct CollisionObject* objectEnteri
         return TRIGGER_TYPE_TO_MASK(ObjectTriggerTypePlayer);
     }
 
-    int decorType = decorIdForObjectDefinition((struct DecorObjectDefinition*)objectEnteringTrigger->collider);
-
+    int decorType = decorIdForCollisionObject(objectEnteringTrigger);
     if (decorType == DECOR_TYPE_CUBE || decorType == DECOR_TYPE_CUBE_UNIMPORTANT) {
         return gScene.player.grabConstraint.object == objectEnteringTrigger ? TRIGGER_TYPE_TO_MASK(ObjectTriggerTypeCubeHover) | TRIGGER_TYPE_TO_MASK(ObjectTriggerTypeCube) : TRIGGER_TYPE_TO_MASK(ObjectTriggerTypeCube);
     }


### PR DESCRIPTION
See [this comment](https://github.com/mwpenny/portal64-still-alive/pull/31#issuecomment-1983998665) in #31.

Added `int decorIdForCollisionObject(struct CollisionObject* collisionObject)` to `decor_object_list` and replaced all relevant calls.