### PR TITLE
Apply blender object scale to fizzlers

### DIFF
--- a/src/scene/fizzler.c
+++ b/src/scene/fizzler.c
@@ -156,7 +156,7 @@ void fizzlerInit(struct Fizzler* fizzler, struct Transform* transform, float wid
     collisionObjectUpdateBB(&fizzler->collisionObject);
     collisionSceneAddDynamicObject(&fizzler->collisionObject);
 
-    fizzler->maxExtent = (int)(width * SCENE_SCALE * 0.5f);
+    fizzler->maxExtent = (int)(maxf(0.0f, width - 0.5f) * SCENE_SCALE);
     fizzler->maxVerticalExtent = (int)(height * SCENE_SCALE);
 
     fizzler->particleCount = (int)(width * height * FIZZLER_PARTICLES_PER_1x1);
@@ -203,7 +203,7 @@ void fizzlerInit(struct Fizzler* fizzler, struct Transform* transform, float wid
     }
 
     fizzler->oldestParticleIndex = 0;
-    fizzler->dynamicId = dynamicSceneAdd(fizzler, fizzlerRender, &fizzler->rigidBody.transform.position, sqrtf(width * width + height * height) * 0.5f);
+    fizzler->dynamicId = dynamicSceneAdd(fizzler, fizzlerRender, &fizzler->rigidBody.transform.position, sqrtf(width * width + height * height));
 
     dynamicSceneSetRoomFlags(fizzler->dynamicId, ROOM_FLAG_FROM_INDEX(room));
 

--- a/tools/level_scripts/entities.lua
+++ b/tools/level_scripts/entities.lua
@@ -117,14 +117,14 @@ sk_definition_writer.add_definition('elevators', 'struct ElevatorDefinition[]', 
 local fizzlers = {}
 
 for _, fizzler in pairs(sk_scene.nodes_for_type('@fizzler')) do
-    local position, rotation = fizzler.node.full_transformation:decompose()
+    local position, rotation, scale = fizzler.node.full_transformation:decompose()
 
     local room_index = room_export.node_nearest_room_index(fizzler.node)
 
     table.insert(fizzlers, {
         position,
         rotation,
-        1,
+        scale.x,
         1,
         room_index,
         signals.optional_signal_index_for_name(fizzler.arguments[1]),

--- a/tools/level_scripts/entities.lua
+++ b/tools/level_scripts/entities.lua
@@ -118,13 +118,15 @@ local fizzlers = {}
 
 for _, fizzler in pairs(sk_scene.nodes_for_type('@fizzler')) do
     local position, rotation, scale = fizzler.node.full_transformation:decompose()
+	local bounding_box = fizzler.node.meshes[1].bb
+	local width = (bounding_box.max.x - bounding_box.min.x) * scale.x * 0.5
 
     local room_index = room_export.node_nearest_room_index(fizzler.node)
 
     table.insert(fizzlers, {
         position,
         rotation,
-        scale.x,
+        width,
         1,
         room_index,
         signals.optional_signal_index_for_name(fizzler.arguments[1]),


### PR DESCRIPTION
See Issue #38

The in addition to position and rotation, the scale (in x-direction) of the blender object is now also taken into account. Interestingly, this was already prepared to be added, as e.g. the `entities.lua` script previously always passed a hardcoded scale of 1.

This means we have to keep the scale intact when transforming `@fizzler` objects in blender (i.e. not use "apply scale" to bring the scale back to `1.0` in xyz). Using the full mesh information like for `@trigger` objects is not necessary and would only complicate things further e.g. with the rotation etc.

![chamber15_first_room](https://github.com/mwpenny/portal64-still-alive/assets/2451901/b5f8af20-716f-4216-9efc-436e2cba20ef)