### PR TITLE
Constrain y-offset of grab to match PC version and circumvent buggy behavior

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -23,6 +23,8 @@
 #include "../build/assets/models/portal_gun/w_portalgun.h"
 
 #define GRAB_RAYCAST_DISTANCE   2.5f
+#define GRAB_MAX_OFFSET_Y       1.1f
+
 #define DROWN_TIME              2.0f
 #define STEP_TIME               0.35f
 
@@ -426,8 +428,8 @@ void playerUpdateGrabbedObject(struct Player* player) {
         
         // determine object target height
         quatMultVector(&player->lookTransform.rotation, &temp_grab_dist, &grabPoint);
-        float grabY = grabPoint.y;
-//
+        float grabY = maxf(minf(grabPoint.y, GRAB_MAX_OFFSET_Y), -GRAB_MAX_OFFSET_Y);
+        
         // keep object at steady XZ-planar distance in front of player
         struct Quaternion forwardRotation;
         struct Vector3 forward, forwardNegate, right;


### PR DESCRIPTION
See Issue #52, specifically [this comment](https://github.com/mwpenny/portal64-still-alive/issues/52#issuecomment-2028793446).