### PR TITLE
Tweak y offset minimum limit to match original game (and due to issue #52)

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -23,7 +23,8 @@
 #include "../build/assets/models/portal_gun/w_portalgun.h"
 
 #define GRAB_RAYCAST_DISTANCE   2.5f
-#define GRAB_MAX_OFFSET_Y       1.25f
+#define GRAB_MIN_OFFSET_Y     -1.1f
+#define GRAB_MAX_OFFSET_Y      1.25f
 
 #define DROWN_TIME              2.0f
 #define STEP_TIME               0.35f
@@ -475,8 +476,8 @@ void playerUpdateGrabbedObject(struct Player* player) {
         
         // determine object target height
         quatMultVector(&player->lookTransform.rotation, &temp_grab_dist, &grabPoint);
-        float grabY = maxf(minf(grabPoint.y, GRAB_MAX_OFFSET_Y), -GRAB_MAX_OFFSET_Y);
-
+        float grabY = maxf(minf(grabPoint.y, GRAB_MAX_OFFSET_Y), GRAB_MIN_OFFSET_Y);
+        
         // keep object at steady XZ-planar distance in front of player
         struct Quaternion forwardRotation;
         struct Vector3 forward, forwardNegate, right;


### PR DESCRIPTION
See issue #52, see PR #54, see [this comment](https://github.com/mwpenny/portal64-still-alive/pull/54#issuecomment-2041202917).