### PR TITLE
Further abstract libultra time types and functions.

### DIFF
--- a/src/graphics/profile_task.c
+++ b/src/graphics/profile_task.c
@@ -5,6 +5,7 @@
 
 #ifdef PORTAL64_WITH_DEBUGGER
 #include "../debugger/serial.h"
+#include "system/time.h"
 #endif
 
 #include <string.h>
@@ -132,7 +133,7 @@ void profileTask(OSSched* scheduler, OSThread* currentThread, OSTask* task, u16*
             osWritebackDCacheAll();
 
 #ifdef PORTAL64_WITH_DEBUGGER
-            OSTime start = osGetTime();
+            Time start = timeGetTime();
 #endif
             osSpTaskStart(task);
             OSMesg recv;
@@ -142,9 +143,9 @@ void profileTask(OSSched* scheduler, OSThread* currentThread, OSTask* task, u16*
             } while ((int)recv != RDP_DONE_MSG);
 
 #ifdef PORTAL64_WITH_DEBUGGER
-            OSTime result = osGetTime() - start;
+            Time result = timeGetTime() - start;
 
-            u64 us = OS_CYCLES_TO_NSEC(result);
+            uint64_t ns = timeNanoseconds(result);
 #endif
 
             // wait for DP to be available
@@ -163,8 +164,8 @@ void profileTask(OSSched* scheduler, OSThread* currentThread, OSTask* task, u16*
                 total,
                 curr->words.w0,
                 curr->words.w1,
-                (int)(us / 1000000), 
-                (int)(us % 1000000)
+                (int)(ns / 1000000),
+                (int)(ns % 1000000)
             );
             gdbSendMessage(GDBDataTypeText, message, messageLen);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -310,7 +310,7 @@ static void gameProc(void* arg) {
                 }
 
                 if (pendingGFX < 2 && drawingEnabled) {
-                    u64 renderStart = profileStart();
+                    Time renderStart = profileStart();
                     graphicsCreateTask(&gGraphicsTasks[drawBufferIndex], gSceneCallbacks->graphicsCallback, gSceneCallbacks->data);
                     profileEnd(renderStart, 1);
                     drawBufferIndex = drawBufferIndex ^ 1;
@@ -325,7 +325,7 @@ static void gameProc(void* arg) {
                 if (inputIgnore) {
                     --inputIgnore;
                 } else {
-                    u64 updateStart = profileStart();
+                    Time updateStart = profileStart();
                     gSceneCallbacks->updateCallback(gSceneCallbacks->data);
                     profileEnd(updateStart, 0);
                     drawingEnabled = 1;

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -604,7 +604,7 @@ void sceneUpdate(struct Scene* scene) {
         scene->checkpointState = SceneCheckpointStateSaved;
     }
     
-    OSTime frameStart = osGetTime();
+    Time frameStart = timeGetTime();
     scene->lastFrameTime = frameStart - scene->lastFrameStart;
     
     if (gGameMenu.state != GameMenuStateResumeGame) {
@@ -775,7 +775,7 @@ void sceneUpdate(struct Scene* scene) {
 
     cutscenesUpdate();
 
-    scene->cpuTime = osGetTime() - frameStart;
+    scene->cpuTime = timeGetTime() - frameStart;
     scene->lastFrameStart = frameStart;
 
     ControllerStick freecam_stick = controllerGetStick(2);

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -65,9 +65,9 @@ struct Scene {
     struct SavedPortal savedPortal;
     struct Effects effects;
     struct Hud hud;
-    OSTime cpuTime;
-    OSTime lastFrameStart;
-    OSTime lastFrameTime;
+    Time cpuTime;
+    Time lastFrameStart;
+    Time lastFrameTime;
     u8 buttonCount;
     u8 decorCount;
     u8 triggerListenerCount;

--- a/src/system/libultra/time_libultra.c
+++ b/src/system/libultra/time_libultra.c
@@ -13,6 +13,18 @@ void timeInit() {
     osCreateMesgQueue(&timerQueue, &timerQueueBuf, 1);
 }
 
+Time timeGetTime() {
+    return (Time)(osGetTime());
+}
+
+uint64_t timeMicroseconds(Time time) {
+    return (uint64_t)(OS_CYCLES_TO_USEC((OSTime)(time)));
+}
+
+uint64_t timeNanoseconds(Time time) {
+    return (uint64_t)(OS_CYCLES_TO_NSEC((OSTime)(time)));
+}
+
 void timeUSleep(uint64_t usec) {
     OSTimer timer;
     OSTime  countdown = OS_USEC_TO_CYCLES((u64)(usec));

--- a/src/system/time.h
+++ b/src/system/time.h
@@ -10,7 +10,12 @@ extern float gFixedDeltaTime;
 #define FRAME_SKIP  1
 #define FIXED_DELTA_TIME    gFixedDeltaTime
 
+typedef uint64_t Time;
+
 void timeInit();
+Time timeGetTime();
+uint64_t timeMicroseconds(Time time);
+uint64_t timeNanoseconds(Time time);
 void timeUSleep(uint64_t usec);
 void timeUpdateDelta();
 void timeSetFrameRate(int fps);

--- a/src/util/profile.c
+++ b/src/util/profile.c
@@ -5,21 +5,21 @@
 #endif
 
 struct ProfileData {
-    u64 lastReportStart;
-    u64 timeAccumulation[MAX_PROFILE_BINS];
+    uint64_t lastReportStart;
+    uint64_t timeAccumulation[MAX_PROFILE_BINS];
 };
 
 struct ProfileData gProfileData;
 
-void profileEnd(u64 startTime, int bin) {
-    gProfileData.timeAccumulation[bin] += OS_CYCLES_TO_USEC(osGetTime() - startTime);
+void profileEnd(Time startTime, int bin) {
+    gProfileData.timeAccumulation[bin] += timeMicroseconds(timeGetTime() - startTime);
 }
 
 void profileReport() {
 #ifdef PORTAL64_WITH_DEBUGGER
-    OSTime reportStartTime = osGetTime();
+    uint64_t reportStartTime = timeMicroseconds(timeGetTime());
 
-    gProfileData.lastReportStart = OS_CYCLES_TO_USEC(reportStartTime - gProfileData.lastReportStart);
+    gProfileData.lastReportStart = reportStartTime - gProfileData.lastReportStart;
     // gdbSendMessage(GDBDataTypeRawBinary, (char*)&gProfileData, sizeof(struct ProfileData));
 
     for (int i = 0; i < MAX_PROFILE_BINS; ++i) {

--- a/src/util/profile.h
+++ b/src/util/profile.h
@@ -1,10 +1,10 @@
 #ifndef __UTIL_PROFILE_H__
 #define __UTIL_PROFILE_H__
 
-#include <ultra64.h>
+#include "system/time.h"
 
-#define profileStart() osGetTime()
-void profileEnd(u64 startTime, int bin);
+#define profileStart() timeGetTime()
+void profileEnd(Time startTime, int bin);
 
 void profileReport();
 


### PR DESCRIPTION
Another PR for issue #65.

libultra time types and functions abstracted:
* replaced `OSTime` with `Time`
* replaced `osGetTime` with `timeGetTime`
* replaced `OS_CYCLES_TO_USEC` with `timeMicroseconds`
* replaced `OS_CYCLES_TO_NSEC` with `timeNanoseconds`

also:
* `lastReportStart` of `ProfileData` was used to store both cycles and microseconds, now it stores only microseconds
* fixed typo in `profileTask`: `ns` instead of `us`