### PR TITLE
Collision Object Callbacks

### DIFF
--- a/src/physics/collision_object.h
+++ b/src/physics/collision_object.h
@@ -17,7 +17,8 @@
 #define COLLISION_OBJECT_PLAYER_STANDING    (1 << 1)
 #define COLLISION_OBJECT_INTERACTED         (1 << 2)
 
-typedef void (*TriggerCallback)(void* data, struct CollisionObject* objectEnteringTrigger);
+typedef void (*TriggerCallback)(struct CollisionObject* collisionObject, struct CollisionObject* objectEnteringTrigger);
+typedef void (*SweptCollideCallback)(struct CollisionObject* collisionObject, float velocityDot);
 
 struct CollisionObject {
     struct ColliderTypeData *collider;
@@ -27,6 +28,7 @@ struct CollisionObject {
     short flags;
     void* data;
     TriggerCallback trigger;
+    SweptCollideCallback sweptCollide;
     u32 manifoldIds;
 };
 

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -141,10 +141,17 @@ void playerRender(void* data, struct DynamicRenderDataList* renderList, struct R
     );
 }
 
+void playerHandleSweptCollision(struct CollisionObject* object, float velocityDot) {
+    // struct Player* player = object->data;
+    playerHandleLandingRumble(-velocityDot);
+}
+
 void playerInit(struct Player* player, struct Location* startLocation, struct Vector3* velocity) {
     player->flyingSoundLoopId = soundPlayerPlay(soundsFastFalling, 0.0f, 0.5f, NULL, NULL, SoundTypeAll);
 
     collisionObjectInit(&player->collisionObject, &gPlayerColliderData, &player->body, 1.0f, PLAYER_COLLISION_LAYERS);
+    player->collisionObject.data = player;
+    player->collisionObject.sweptCollide = playerHandleSweptCollision;
 
     // rigidBodyMarkKinematic(&player->body);
     player->body.flags |= RigidBodyIsKinematic | RigidBodyIsPlayer;

--- a/src/scene/fizzler.c
+++ b/src/scene/fizzler.c
@@ -20,8 +20,8 @@
 
 #define GFX_PER_PARTICLE(particleCount) ((particleCount) + (((particleCount) + 7) >> 3) + 1)
 
-void fizzlerTrigger(void* data, struct CollisionObject* objectEnteringTrigger) {
-    struct Fizzler* fizzler = (struct Fizzler*)data;
+void fizzlerTrigger(struct CollisionObject* collisionObject, struct CollisionObject* objectEnteringTrigger) {
+    struct Fizzler* fizzler = collisionObject->data;
 	
     if (objectEnteringTrigger->body) {
         objectEnteringTrigger->body->flags |= RigidBodyFizzled;

--- a/src/scene/trigger_listener.c
+++ b/src/scene/trigger_listener.c
@@ -23,8 +23,8 @@ enum ObjectTriggerType triggerDetermineType(struct CollisionObject* objectEnteri
     return ObjectTriggerTypeNone;
 }
 
-void triggerTrigger(void* data, struct CollisionObject* objectEnteringTrigger) {
-    struct TriggerListener* listener = data;
+void triggerTrigger(struct CollisionObject* collisionObject, struct CollisionObject* objectEnteringTrigger) {
+    struct TriggerListener* listener = collisionObject->data;
 
     struct Vector3 offset;
     vector3Sub(


### PR DESCRIPTION
Remove player_rumble_clips from collision_object by adding swept collision callback
Collision object trigger passes in the collision object rather than the data pointer