### PR TITLE
wrap inputs in new_game menu

### DIFF
--- a/src/menu/new_game_menu.c
+++ b/src/menu/new_game_menu.c
@@ -168,14 +168,20 @@ enum InputCapture newGameUpdate(struct NewGameMenu* newGameMenu) {
         soundPlayerPlay(SOUNDS_BUTTONCLICKRELEASE, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
-    if ((controllerGetDirectionDown(0) & ControllerDirectionRight) != 0 && 
-        newGameMenu->selectedChapter + 1 < newGameMenu->chapterCount &&
-        gChapters[newGameMenu->selectedChapter + 1].imageData) {
-        newGameMenu->selectedChapter = newGameMenu->selectedChapter + 1;
+    if ((controllerGetDirectionDown(0) & ControllerDirectionRight) != 0) {
+        if (newGameMenu->selectedChapter + 1 < newGameMenu->chapterCount) {
+            if (gChapters[newGameMenu->selectedChapter + 1].imageData)
+                newGameMenu->selectedChapter = newGameMenu->selectedChapter + 1;
+        } else {
+            newGameMenu->selectedChapter = 0;
+        }
     }
-
-    if ((controllerGetDirectionDown(0) & ControllerDirectionLeft) != 0 && newGameMenu->selectedChapter > 0) {
-        newGameMenu->selectedChapter = newGameMenu->selectedChapter - 1;
+    
+    if ((controllerGetDirectionDown(0) & ControllerDirectionLeft) != 0) {
+        if (newGameMenu->selectedChapter > 0)
+            newGameMenu->selectedChapter = newGameMenu->selectedChapter - 1;
+        else
+            newGameMenu->selectedChapter = newGameMenu->chapterCount - 1;
     }
     
     if ((controllerGetDirectionDown(0) & ControllerDirectionLeft) != 0 || (controllerGetDirectionDown(0) & ControllerDirectionRight) != 0)

--- a/src/menu/new_game_menu.c
+++ b/src/menu/new_game_menu.c
@@ -169,12 +169,10 @@ enum InputCapture newGameUpdate(struct NewGameMenu* newGameMenu) {
     }
 
     if ((controllerGetDirectionDown(0) & ControllerDirectionRight) != 0) {
-        if (newGameMenu->selectedChapter + 1 < newGameMenu->chapterCount) {
-            if (gChapters[newGameMenu->selectedChapter + 1].imageData)
-                newGameMenu->selectedChapter = newGameMenu->selectedChapter + 1;
-        } else {
+        if (newGameMenu->selectedChapter + 1 < newGameMenu->chapterCount)
+            newGameMenu->selectedChapter = newGameMenu->selectedChapter + 1;
+        else
             newGameMenu->selectedChapter = 0;
-        }
     }
     
     if ((controllerGetDirectionDown(0) & ControllerDirectionLeft) != 0) {


### PR DESCRIPTION
Changes the behaviour of the "new game" menu to

- jump to the last chapter if you move left from the first chapter
- and to jump to the first chapter if you move right from the last chapter.

We did it like that at the "load game" menu (with up & down), I do not know why it was not done this way with "new game".

I like it infinitely better like this!

Not sure if we should move the .imageData check to the bottom for all operations.