### PR TITLE
Update Dockerfile - LegacyKeyValueFormat Build Check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:24.04
 
 WORKDIR /usr/src/app
 
-ENV PATH /opt/crashsdk/bin:$PATH
-ENV PATH /root/.local/bin:$PATH
-ENV ROOT /etc/n64
+ENV PATH=/opt/crashsdk/bin:$PATH
+ENV PATH=/root/.local/bin:$PATH
+ENV ROOT=/etc/n64
 
 RUN apt-get update -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Updating the Dockerfile to remedy the  3 warnings found:
```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 5)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 6)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 7)
```