### PR TITLE
GLaDOS Voice Volume Fade Fix

### DIFF
--- a/src/audio/soundplayer.c
+++ b/src/audio/soundplayer.c
@@ -353,11 +353,11 @@ void soundPlayerUpdate() {
             continue;
         }
 
+        sound->estimatedTimeLeft -= FIXED_DELTA_TIME;
+
         if (sound->soundType == SoundTypeVoice && sound->estimatedTimeLeft > 0.0f) {
             isVoiceActive = 1;
         }
-
-        sound->estimatedTimeLeft -= FIXED_DELTA_TIME;
 
         alSndpSetSound(&gSoundPlayer, sound->soundId);
 

--- a/src/audio/soundplayer.c
+++ b/src/audio/soundplayer.c
@@ -353,7 +353,7 @@ void soundPlayerUpdate() {
             continue;
         }
 
-        if (sound->soundType == SoundTypeVoice) {
+        if (sound->soundType == SoundTypeVoice && sound->estimatedTimeLeft > 0.0f) {
             isVoiceActive = 1;
         }
 


### PR DESCRIPTION
Here is the quick and dirty fix for the hanging volume fade for when GLaDOS finishes speaking, as mentioned in https://github.com/mwpenny/portal64-still-alive/issues/105

This is a temporary fix which could be removed once https://github.com/mwpenny/portal64-still-alive/issues/116 is resolved.