### PR TITLE
Audio Crackle & Max Sounds Fix

### DIFF
--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -24,7 +24,7 @@
 #define MAX_RSP_CMDS            4096   /* max number of commands in any command list.   */
                                        /* Mainly dependent on sequences used            */
 
-#define NUM_DMA_BUFFERS         24     /* max number of dma buffers needed.             */
+#define NUM_DMA_BUFFERS         30     /* max number of dma buffers needed.             */
                                        /* Mainly dependent on sequences and sfx's       */
 
 #define NUM_DMA_MESSAGES        32     /* The maximum number of DMAs any one frame can  */

--- a/src/audio/soundplayer.c
+++ b/src/audio/soundplayer.c
@@ -18,8 +18,8 @@ extern char _soundsTblSegmentRomEnd[];
 struct SoundArray* gSoundClipArray;
 ALSndPlayer gSoundPlayer;
 
-#define MAX_SKIPPABLE_SOUNDS    6
-#define MAX_ACTIVE_SOUNDS       12
+#define MAX_SKIPPABLE_SOUNDS    20
+#define MAX_ACTIVE_SOUNDS       26
 
 #define SOUND_FLAGS_3D          (1 << 0)
 #define SOUND_FLAGS_LOOPING     (1 << 1)


### PR DESCRIPTION
While issue https://github.com/mwpenny/portal64-still-alive/issues/116 (envelope/sample rate bug) has been progressing, I took another look at possible root causes for the max sounds & crackle issue (originally addressed in https://github.com/mwpenny/portal64-still-alive/commit/0bebdbd8b92a1c43ab5f4cd6d5b65fad113db18a).

And what I found is that simply adding a few more audio DMA buffers here (6** in this case, +12kb?):

https://github.com/mwpenny/portal64-still-alive/blob/4c360fc3d61a4c9596a5679a6b6620abf4fff951/src/audio/audio.h#L27

It completely fixes all crackle and audio glitches, even with over twice as many simul-sounds. 

I've tested these changes on OG hardware and I'm unable to replicate any kind of audible glitch, even with the still present 'hanging sound clip' issue mentioned above.  

Regardless of which way you decide to handle the #116 issue, I hope that this might be one of the final tweaks required to finally ease the constraints on the number of sound.  *Testing with any of my envelope/hang fix, lower sample rate builds is even more impressive!* 

** Totally arbitrary. I have no idea what the correct value should be, but documentation suggests that it be some ratio of the DMA buffer length; 0x800, which is quite large compared to the examples. I tried a few variations of buffer length vs. num. buffers, but this combo just worked. 




