### PR TITLE
Fix for excess footstep sounds

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -54,11 +54,11 @@
 #define PLAYER_ACCEL            (20.0f)
 #define PLAYER_AIR_ACCEL        (15.0f)
 #define PLAYER_FRICTION         (5.875f)
-#define PLAYER_LAND_STEP_VEL    2.2f
 
 #define FRICTION_STOP_THRESHOLD (190.0f / 64.0f)
 #define FLING_THRESHOLD_VEL     (5.0f)
 #define JUMP_BOOST_LIMIT        (PLAYER_SPEED * 1.5f)
+#define LAND_FALL_THRESHOLD_VEL (2.2f)
 
 #define MIN_ROTATE_RATE         (M_PI * 0.5f)
 #define MAX_ROTATE_RATE         (M_PI * 3.5f)
@@ -564,6 +564,11 @@ void playerUpdateSounds(struct Player* player) {
         soundPlayerPlay(soundsConcreteFootstep[3], 1.0f, 1.0f, NULL, NULL, SoundTypeAll);
         player->flags &= ~PlayerJustJumped;
     }
+    if (flags & PlayerJustLandedFromFall) {
+        // TODO: Dead body sound when landing on ground while dead
+        soundPlayerPlay(soundsConcreteFootstep[2], 1.0f, 1.0f, NULL, NULL, SoundTypeAll);
+        player->flags &= ~PlayerJustLandedFromFall;
+    }
     if (flags & PlayerJustSelect) {
         soundPlayerPlay(soundsSelecting[1], 1.0f, 1.0f, NULL, NULL, SoundTypeAll);
         player->flags &= ~PlayerJustSelect;
@@ -768,12 +773,10 @@ void playerUpdateFooting(struct Player* player, float maxStandDistance) {
         if (player->body.velocity.y < 0.0f) {
             playerHandleLandingRumble(-player->body.velocity.y);
 
-            // Only play landing footstep sound if the player is moving downward with enough velocity.
-            if (player->body.velocity.y < -PLAYER_LAND_STEP_VEL) {
-                soundPlayerPlay(soundsConcreteFootstep[2], 1.0f, 1.0f, NULL, NULL, SoundTypeAll);
+            // Only consider it a fall moving downward with enough velocity
+            if (player->body.velocity.y < -LAND_FALL_THRESHOLD_VEL) {
+                player->flags |= PlayerJustLandedFromFall;
             }
-
-            // TODO: Dead body sound when landing on ground while dead
 
             player->body.velocity.y = 0.0f;
         }

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -21,6 +21,7 @@ enum PlayerFlags {
     PlayerCrouched = (1 << 3),
     PlayerIsStepping = (1 << 4),
     PlayerJustJumped = (1 << 5),
+    PlayerJustLandedFromFall = (1 << 6),
     PlayerJustSelect = (1 << 7),
     PlayerJustDeniedSelect = (1 << 8),
     PlayerJustShotPortalGun = (1 << 9),


### PR DESCRIPTION
Here's a quick tweak & fix for some of the footstep sounds which I found to be misbehaving.

I found that the landing footstep sound was being played far too often, particularly when running down stairs. This is most evident at the start of Chamber 11.  Also, the landing sound doesn't play in the OG game when the player jumps while standing still, and this fix makes that behavior match as well.